### PR TITLE
client-docs-links-amazon-in-app

### DIFF
--- a/docs/guides/in-app-purchases/amazon-in-app-purchases.md
+++ b/docs/guides/in-app-purchases/amazon-in-app-purchases.md
@@ -8,7 +8,7 @@ The InPlayer system integrates with native apps (the Amazon app in this case) on
 
 You can find the dedicated integration page [here.](https://dashboard.inplayer.com/settings/integrations/in-app-integrations) 
 
-For a more detailed and visual representation of the integration set-up, click [here.](https://inplayer.com/docs/in-app-purchases/amazon/?origin_team=T0EQL0NCA)
+For a more detailed and visual representation of the integration set-up, click [here.](https://client.support.inplayer.com/integrations/in-app-integrations/amazon/)
 
 
 Once the integration is set up and you have your merchant offers created, you can then proceed with the implementation of the in-app payment process. 


### PR DESCRIPTION
Change old client support documentation links with new ones