### PR TITLE
Standalone Subscription Option

### DIFF
--- a/docs/paywall3.md
+++ b/docs/paywall3.md
@@ -717,10 +717,11 @@ Here is the list of the HTML classes that can be used for creating each of the s
 |--------------|---------------|
 | `inplayer-paywall-login`	| Invokes the login screen of the paywall | 
 | `inplayer-paywall-logout`	| Invokes the logout action  | 
-| `inplayer-paywall-account`	 | Invokes the 'My Account' screen of the registered user | 
+| `inplayer-paywall-account`	 | Invokes the 'My Account' screen of the registered viewer | 
 | `inplayer-paywall-ccm`      | Invokes the  default card management screen | 
 | `inplayer-paywall-change-pass`  | Invokes the 'Change Password' screen | 
-| `inplayer-paywall-purchases`  | Invokes the 'My Purchases' paywall screen where an end-user can see the list of payments they have completed | 
+| `inplayer-paywall-purchases`  | Invokes the 'My Purchases' paywall screen where a viewer can see the list of payments they have completed | 
+| `inplayer-paywall-subscriptions`	| Invokes the 'Subscriptions' paywall screen where a viewer can see their subscriptions | 
 | `inplayer-paywall-donations`	| Invokes the donations flow for the provided asset. See below for example of usage  | 
 | `inplayer-paywall-gifts`	| Invokes the gifts flow for the provided asset. See below for example of usage  |
 


### PR DESCRIPTION
This is a PR that includes the addition of a new standalone option, named `inplayer-paywall-subscriptions` that invokes the subscriptions screen of the paywall