### PR TITLE
Update webhooks.md

### DIFF
--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -18,7 +18,7 @@ Each event type has a specific payload format. The InPlayer webhooks’ payload 
 
 ### Payload headers
 
-The HTTP POST requests sent to your webhook URL have several **headers**, including the **custom InPlayer signature header**. You will use this signature to validate the event concerned, as described in the validating events section.
+The HTTP POST requests sent to your webhook URL have several **headers**, including the **custom InPlayer signature header**. You will use this signature to validate the event concerned, as described in the [Validating Events](#validating-events) section.
 
 | Header        | Value           |
 | ------------- |-------------|


### PR DESCRIPTION
[DOCS-2508] Adds direct link to Validating Events section from the Payloads section

@matejpetrovjwp Do you mind approved this this? I don't remember the process for publishing changes to the InPlayer docs.

[DOCS-2508]: https://jwplayer.atlassian.net/browse/DOCS-2508?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ